### PR TITLE
Replace unmount hack w/ container stop loop to properly shutdown daemon

### DIFF
--- a/jobs/docker/templates/bin/docker_ctl
+++ b/jobs/docker/templates/bin/docker_ctl
@@ -78,14 +78,23 @@ case $1 in
     ;;
 
   stop)
-    # Stop Docker daemon
-    kill_and_wait ${DOCKER_PID_FILE}
-
-    # Hack: Seems Docker is not releasing the mountpoint for its store dir
-    mounted=$(cat /proc/mounts | grep ${DOCKER_STORE_DIR}/docker)
-    if [ ! -z "${mounted}" ]; then
-        umount ${DOCKER_STORE_DIR}/docker
+    # Stop Docker containers
+    echo -n "Stopping docker containers: "
+    containers="$(chpst -u ${DOCKER_USER}:${DOCKER_GROUP} docker --host unix://${DOCKER_PID_DIR}/docker.sock ps -q)"
+    if [[ ! -z $containers ]]; then
+      echo ${containers}
+      for container in $containers
+      do
+        echo -n "Stopping docker container... "
+        chpst -u ${DOCKER_USER}:${DOCKER_GROUP} docker --host unix://${DOCKER_PID_DIR}/docker.sock stop ${container}
+      done
+    else
+      echo "Nothing to do."
     fi
+
+    # Stop Docker daemon
+    echo -n "Stopping docker daemon..."
+    kill_and_wait ${DOCKER_PID_FILE}
     ;;
 
   *)


### PR DESCRIPTION
#### Purpose
Solve unmount issue when undeploying/updating docker jobs.

#### Motivation
The bosh/monit kill routine will kill a docker daemon if it doesn't stop within the set grace period. This routine has no knowledge about the containers, so if the docker daemon doesn't respond fast enough, this will lead to the unmount issue.

#### Proposal
Better let the daemon kill its containers. It will first issue SIGTERM and then SIGKILL, but it will remain in control of the shutdown process for the containers. Only then stop the docker daemon.

#### Changes
* Stop all running containers before stopping the docker daemon
* Remove former unmount hack

#### Steps to Test or Reproduce
Deploy broker, create non-trivial service instance (e.g. redis), check that a corresponding docker container was started, undeploy broker. Before this PR, undeploy (or update) failed with ```umount: /var/vcap/store: device is busy```

#### Issues
https://github.com/cf-platform-eng/cf-containers-broker/issues/16

#### CC
@frodenas @holgerkoser @poblin-orange