### PR TITLE
Integrate Pivotal broker-registrar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/swarm"]
 	path = src/swarm
 	url = https://github.com/docker/swarm.git
+[submodule "src/broker-registrar"]
+	path = src/broker-registrar
+	url = https://github.com/pivotal-cf/broker-registrar.git

--- a/examples/docker-broker-aws.yml
+++ b/examples/docker-broker-aws.yml
@@ -33,13 +33,22 @@ networks:
     cloud_properties:
       security_groups:
         - bosh
-        - <%= deployment_name %
+        - <%= deployment_name %>
 
   - name: elastic
     type: vip
     cloud_properties: {}
 
 resource_pools:
+  - name : errand
+    network: default
+    size: 1
+    stemcell:
+      name: bosh-aws-xen-ubuntu-trusty-go_agent
+      version: latest
+    cloud_properties:
+      instance_type: m1.small
+
   - name: default
     network: default
     size: 1
@@ -64,6 +73,22 @@ jobs:
         static_ips:
           - <%= elastic_ip %>
 
+  - name: broker-registrar
+    template: broker-registrar
+    instances: 1
+    resource_pool: errand
+    lifecycle: errand
+    networks:
+      - name: default
+
+  - name: broker-deregistrar
+    template: broker-deregistrar
+    instances: 1
+    resource_pool: errand
+    lifecycle: errand
+    networks:
+      - name: default
+
 properties:
   nats:
     user: nats
@@ -72,12 +97,17 @@ properties:
     machines:
       - 0.core.default.cf.microbosh
 
-  cfcontainersbroker:
-    auth_username: 'containers'
-    auth_password: 'containers'
+  cf:
+    api_url: "<%= protocol %>://api.<%= root_domain %>"
+    admin_username: 'admin'
+    admin_password: 'admin'
+
+  broker:
+    name: cf-containers-broker
+    host: "cf-containers-broker.<%= root_domain %>"
+    username: 'containers'
+    password: 'containers'
     cookie_secret: 'e7247dae-a252-4393-afa3-2219c1c02efd'
-    cc_api_uri: "<%= protocol %>://api.<%= root_domain %>"
-    external_host: "cf-containers-broker.<%= root_domain %>"
     component_name: 'cf-containers-broker'
     max_containers: 20
 

--- a/examples/docker-broker-bosh-lite.yml
+++ b/examples/docker-broker-bosh-lite.yml
@@ -64,6 +64,25 @@ jobs:
     persistent_disk: 65536
     networks:
       - name: default
+        default: [dns, gateway]
+        static_ips:
+          - 10.244.8.2
+
+  - name: broker-registrar
+    template: broker-registrar
+    instances: 1
+    resource_pool: default
+    lifecycle: errand
+    networks:
+      - name: default
+
+  - name: broker-deregistrar
+    template: broker-deregistrar
+    instances: 1
+    resource_pool: default
+    lifecycle: errand
+    networks:
+      - name: default
 
 properties:
   nats:
@@ -73,12 +92,17 @@ properties:
     machines:
       - 10.244.0.6
 
-  cfcontainersbroker:
-    auth_username: 'containers'
-    auth_password: 'containers'
+  cf:
+    api_url: "https://api.10.244.0.34.xip.io"
+    admin_username: 'admin'
+    admin_password: 'admin'
+
+  broker:
+    name: cf-containers-broker
+    host: "cf-containers-broker.10.244.0.34.xip.io"
+    username: 'containers'
+    password: 'containers'
     cookie_secret: 'e7247dae-a252-4393-afa3-2219c1c02efd'
-    cc_api_uri: "https://api.10.244.0.34.xip.io"
-    external_host: "cf-containers-broker.10.244.0.34.xip.io"
     component_name: 'cf-containers-broker'
     max_containers: 20
 

--- a/examples/docker-broker-google.yml
+++ b/examples/docker-broker-google.yml
@@ -41,6 +41,15 @@ networks:
     cloud_properties: {}
 
 resource_pools:
+  - name : errand
+    network: default
+    size: 1
+    stemcell:
+      name: bosh-google-kvm-ubuntu-trusty
+      version: latest
+    cloud_properties:
+      instance_type: n1-standard-8
+
   - name: default
     network: default
     size: 1
@@ -65,6 +74,22 @@ jobs:
         static_ips:
           - <%= static_ip %>
 
+  - name: broker-registrar
+    template: broker-registrar
+    instances: 1
+    resource_pool: errand
+    lifecycle: errand
+    networks:
+      - name: default
+
+  - name: broker-deregistrar
+    template: broker-deregistrar
+    instances: 1
+    resource_pool: errand
+    lifecycle: errand
+    networks:
+      - name: default
+
 properties:
   nats:
     user: nats
@@ -73,12 +98,17 @@ properties:
     machines:
       - 0.core.default.cf.microbosh
 
-  cfcontainersbroker:
-    auth_username: 'containers'
-    auth_password: 'containers'
+  cf:
+    api_url: "<%= protocol %>://api.<%= root_domain %>"
+    admin_username: 'admin'
+    admin_password: 'admin'
+
+  broker:
+    name: cf-containers-broker
+    host: "cf-containers-broker.<%= root_domain %>"
+    username: 'containers'
+    password: 'containers'
     cookie_secret: 'e7247dae-a252-4393-afa3-2219c1c02efd'
-    cc_api_uri: "<%= protocol %>://api.<%= root_domain %>"
-    external_host: "cf-containers-broker.<%= root_domain %>"
     component_name: 'cf-containers-broker'
     max_containers: 20
 

--- a/examples/docker-broker-openstack.yml
+++ b/examples/docker-broker-openstack.yml
@@ -40,6 +40,15 @@ networks:
     cloud_properties: {}
 
 resource_pools:
+  - name : errand
+    network: default
+    size: 1
+    stemcell:
+      name: bosh-openstack-kvm-ubuntu-trusty-go_agent
+      version: latest
+    cloud_properties:
+      instance_type: m1.small
+
   - name: default
     network: default
     size: 1
@@ -64,6 +73,22 @@ jobs:
         static_ips:
           - <%= floating_ip %>
 
+  - name: broker-registrar
+    template: broker-registrar
+    instances: 1
+    resource_pool: errand
+    lifecycle: errand
+    networks:
+      - name: default
+
+  - name: broker-deregistrar
+    template: broker-deregistrar
+    instances: 1
+    resource_pool: errand
+    lifecycle: errand
+    networks:
+      - name: default
+
 properties:
   nats:
     user: nats
@@ -72,12 +97,17 @@ properties:
     machines:
       - 0.core.default.cf.microbosh
 
-  cfcontainersbroker:
-    auth_username: 'containers'
-    auth_password: 'containers'
+  cf:
+    api_url: "<%= protocol %>://api.<%= root_domain %>"
+    admin_username: 'admin'
+    admin_password: 'admin'
+
+  broker:
+    name: cf-containers-broker
+    host: "cf-containers-broker.<%= root_domain %>"
+    username: 'containers'
+    password: 'containers'
     cookie_secret: 'e7247dae-a252-4393-afa3-2219c1c02efd'
-    cc_api_uri: "<%= protocol %>://api.<%= root_domain %>"
-    external_host: "cf-containers-broker.<%= root_domain %>"
     component_name: 'cf-containers-broker'
     max_containers: 20
 

--- a/jobs/broker-deregistrar
+++ b/jobs/broker-deregistrar
@@ -1,0 +1,1 @@
+../src/broker-registrar/bosh/jobs/broker-deregistrar

--- a/jobs/broker-registrar
+++ b/jobs/broker-registrar
@@ -1,0 +1,1 @@
+../src/broker-registrar/bosh/jobs/broker-registrar

--- a/jobs/cf-containers-broker/spec
+++ b/jobs/cf-containers-broker/spec
@@ -18,57 +18,58 @@ templates:
   config/unicorn.conf.rb.erb: config/unicorn.conf.rb
 
 properties:
-  cfcontainersbroker.user:
+  broker.user:
     description: 'User which will own the CF-Containers-Broker services'
     default: 'root'
-  cfcontainersbroker.group:
+  broker.group:
     description: 'Group which will own the CF-Containers-Broker services'
     default: 'vcap'
-  cfcontainersbroker.unicorn.worker_processes:
+  broker.unicorn.worker_processes:
     description: 'Unicorn worker processes'
     default: '4'
-  cfcontainersbroker.unicorn.port:
+  broker.unicorn.port:
     description: 'Unicorn listen port'
     default: '80'
-  cfcontainersbroker.auth_username:
+  broker.username:
     description: "Broker's basic auth username"
-  cfcontainersbroker.auth_password:
+  broker.password:
     description: "Broker's basic auth password"
-  cfcontainersbroker.cookie_secret:
+  broker.cookie_secret:
     description: 'A unique secret key, used to sign sessions'
-  cfcontainersbroker.session_expiry:
+  broker.session_expiry:
     description: 'Session expiry time of the session'
     default: '86400'
-  cfcontainersbroker.cc_api_uri:
-    description: 'URL of the CloudFoundry Cloud Controller'
-  cfcontainersbroker.external_host:
+  broker.host:
     description: 'Host used to register the broker'
-  cfcontainersbroker.component_name:
+  broker.component_name:
     description: 'Component name used to register the broker'
     default: 'cf-containers-broker'
-  cfcontainersbroker.ssl_enabled:
+  broker.ssl_enabled:
     description: 'Determines use of https in dashboard url and in callback uri for calls to UAA'
     default: false
-  cfcontainersbroker.skip_ssl_validation:
+  broker.skip_ssl_validation:
     description: 'Determines whether dashboard verifies SSL certificates when communicating with Cloud Controller and UAA'
     default: true
-  cfcontainersbroker.max_containers:
+  broker.max_containers:
     description: 'Max number of containers'
     default: '0'
-  cfcontainersbroker.fetch_images:
+  broker.fetch_images:
     description: 'Fetch new/updated container images on restart'
     default: true
-  cfcontainersbroker.services:
+  broker.services:
     description: 'Services and plans offered by the broker'
-  cfcontainersbroker.logrotate.frequency:
+  broker.logrotate.frequency:
     description: 'Frequency to run logrotate for Docker daemon log files (crontab five time and date fields)'
     default: '0 * * * *'
-  cfcontainersbroker.logrotate.rotate:
+  broker.logrotate.rotate:
     description: 'Number of times Docker daemon log files are rotated before being removed '
     default: '7'
-  cfcontainersbroker.logrotate.size:
+  broker.logrotate.size:
     description: 'Size before Docker daemon log files are rotateds'
     default: '2M'
+
+  cf.api_url:
+    description: 'URL of the CloudFoundry Cloud Controller'
 
   nats.user:
     description: 'Username for broker to connect to NATS'

--- a/jobs/cf-containers-broker/templates/bin/job_properties.sh.erb
+++ b/jobs/cf-containers-broker/templates/bin/job_properties.sh.erb
@@ -20,12 +20,12 @@ export CF_CONTAINERS_BROKER_STORE_DIR=$STORE_DIR
 export CF_CONTAINERS_BROKER_TMP_DIR=$TMP_DIR
 
 # User which will own the CF-Containers-Broker services
-export CF_CONTAINERS_BROKER_USER="<%= p('cfcontainersbroker.user') %>"
+export CF_CONTAINERS_BROKER_USER="<%= p('broker.user') %>"
 
 # Group which will own the CF-Containers-Broker services
-export CF_CONTAINERS_BROKER_GROUP="<%= p('cfcontainersbroker.group') %>"
+export CF_CONTAINERS_BROKER_GROUP="<%= p('broker.group') %>"
 
-export CF_CONTAINERS_FETCH_IMAGES=<%= p('cfcontainersbroker.fetch_images') ? 'true' : '' %>
+export CF_CONTAINERS_FETCH_IMAGES=<%= p('broker.fetch_images') ? 'true' : '' %>
 
 # CF-Containers-Broker Gemfile
 export BUNDLE_GEMFILE=/var/vcap/packages/cf-containers-broker/Gemfile

--- a/jobs/cf-containers-broker/templates/config/logrotate.conf.erb
+++ b/jobs/cf-containers-broker/templates/config/logrotate.conf.erb
@@ -1,10 +1,10 @@
 /var/vcap/sys/log/cf-containers-broker/*.log {
   missingok
-  rotate <%= p('cfcontainersbroker.logrotate.rotate') %>
+  rotate <%= p('broker.logrotate.rotate') %>
   compress
   delaycompress
   notifempty
   copytruncate
-  size <%= p('cfcontainersbroker.logrotate.size') %>
-  su <%= p('cfcontainersbroker.user') %> <%= p('cfcontainersbroker.group') %>
+  size <%= p('broker.logrotate.size') %>
+  su <%= p('broker.user') %> <%= p('broker.group') %>
 }

--- a/jobs/cf-containers-broker/templates/config/logrotate.cron.erb
+++ b/jobs/cf-containers-broker/templates/config/logrotate.cron.erb
@@ -1,1 +1,1 @@
-<%= p('cfcontainersbroker.logrotate.frequency') %> test -x /usr/sbin/logrotate && /usr/sbin/logrotate --state /var/vcap/sys/tmp/cf-containers-broker/logrotate.status /var/vcap/jobs/cf-containers-broker/config/logrotate.conf >>/var/vcap/sys/log/cf-containers-broker/logrotate_cron.log 2>&1
+<%= p('broker.logrotate.frequency') %> test -x /usr/sbin/logrotate && /usr/sbin/logrotate --state /var/vcap/sys/tmp/cf-containers-broker/logrotate.status /var/vcap/jobs/cf-containers-broker/config/logrotate.conf >>/var/vcap/sys/log/cf-containers-broker/logrotate_cron.log 2>&1

--- a/jobs/cf-containers-broker/templates/config/settings.yml.erb
+++ b/jobs/cf-containers-broker/templates/config/settings.yml.erb
@@ -1,11 +1,11 @@
 production:
   log_path: '/var/vcap/sys/log/cf-containers-broker/cf-containers-broker.log'
-  auth_username: '<%= p('cfcontainersbroker.auth_username') %>'
-  auth_password: '<%= p('cfcontainersbroker.auth_password') %>'
-  cookie_secret: <%= p('cfcontainersbroker.cookie_secret') %>
-  session_expiry: <%= p('cfcontainersbroker.session_expiry') %>
+  auth_username: '<%= p('broker.username') %>'
+  auth_password: '<%= p('broker.password') %>'
+  cookie_secret: <%= p('broker.cookie_secret') %>
+  session_expiry: <%= p('broker.session_expiry') %>
 
-  cc_api_uri: <%= p('cfcontainersbroker.cc_api_uri') %>
+  cc_api_uri: <%= p('cf.api_url') %>
   <%
     def openstruct_to_hash(os)
       os.marshal_dump.map do |key, element|
@@ -17,19 +17,19 @@ production:
     external_ip = networks.values.find { |net| net.has_key?(:default) }[:ip]
    %>
   external_ip: <%= external_ip %>
-  external_host: <%= p('cfcontainersbroker.external_host') %>
-  external_port: <%= p('cfcontainersbroker.unicorn.port') %>
-  component_name: <%= p('cfcontainersbroker.component_name') %>
+  external_host: <%= p('broker.host') %>
+  external_port: <%= p('broker.unicorn.port') %>
+  component_name: <%= p('broker.component_name') %>
 
-  ssl_enabled: <%= p('cfcontainersbroker.ssl_enabled') %>
-  skip_ssl_validation: <%= p('cfcontainersbroker.skip_ssl_validation') %>
+  ssl_enabled: <%= p('broker.ssl_enabled') %>
+  skip_ssl_validation: <%= p('broker.skip_ssl_validation') %>
 
   host_directory: /var/vcap/store/cf-containers-broker/
-  max_containers: <%= p('cfcontainersbroker.max_containers') %>
+  max_containers: <%= p('broker.max_containers') %>
 
   message_bus_servers:
   <% p('nats.machines').each do |ip| %>
     - nats://<%= p('nats.user') %>:<%= p('nats.password') %>@<%= ip %>:<%= p('nats.port') %>
   <% end %>
 
-  services: <%= JSON.pretty_generate(p('cfcontainersbroker.services')) %>
+  services: <%= JSON.pretty_generate(p('broker.services')) %>

--- a/jobs/cf-containers-broker/templates/config/unicorn.conf.rb.erb
+++ b/jobs/cf-containers-broker/templates/config/unicorn.conf.rb.erb
@@ -2,13 +2,13 @@
 
 # Use at least one worker per core if you're on a dedicated server,
 # more will usually help for _short_ waits on databases/caches.
-worker_processes <%= p('cfcontainersbroker.unicorn.worker_processes') %>
+worker_processes <%= p('broker.unicorn.worker_processes') %>
 
 # Help ensure your application will always spawn in the "current" directory
 working_directory '/var/vcap/packages/cf-containers-broker'
 
 # listen on a TCP port
-listen <%= p('cfcontainersbroker.unicorn.port') %>, :tcp_nopush => true
+listen <%= p('broker.unicorn.port') %>, :tcp_nopush => true
 
 # location of the pid file
 pid '/var/vcap/sys/run/cf-containers-broker/cf-containers-broker.pid'

--- a/packages/broker-registrar
+++ b/packages/broker-registrar
@@ -1,0 +1,1 @@
+../src/broker-registrar/bosh/packages/broker-registrar


### PR DESCRIPTION
#### Purpose
Simplify registration of the broker at the CF CC.

#### Motivation
The current release requires manual (or otherwise automated) registration of the broker at the CF CC. There is however a Pivotal broker-registrar that would be handy to use instead.

#### Proposal
Integrate https://github.com/pivotal-cf/broker-registrar.

#### Changes
* Add new submodule with the Pivotal broker-registrar
* Add jobs for registration and deregistration to all deployment samples
* Add missing properties and rename former ```cfcontainersbroker``` properties into ```broker```

#### Remark about the changed property names
The Pivotal broker-registrar properties overlap significantly with the docker-boshrelease properties. Unfortunately they are called differently. To avoid property duplicates defining the same data, this change renames all ```cfcontainersbroker``` properties into ```broker``` (as they are called in broker-registrar).

#### Note of caution
Changes were done, tested, and put to production only with our own cloud infrastructure which is neither of the supported ones.

#### CC
@frodenas @holgerkoser