### PR TITLE
Extend Swarm job/deployment to include a broker and become operational

### DIFF
--- a/examples/docker-swarm-bosh-lite.yml
+++ b/examples/docker-swarm-bosh-lite.yml
@@ -31,14 +31,15 @@ networks:
         reserved: [10.244.8.1]
         static: [10.244.8.2]
         cloud_properties: {}
-      # networks for dynamic ips (db, workers, compilation vms)
       - range: 10.244.8.4/30
         reserved: [10.244.8.5]
         static: [10.244.8.6]
         cloud_properties: {}
       - range: 10.244.8.8/30
         reserved: [10.244.8.9]
+        static: [10.244.8.10]
         cloud_properties: {}
+      # networks for dynamic ips (db, workers, compilation vms)
       - range: 10.244.8.12/30
         reserved: [10.244.8.13]
         cloud_properties: {}
@@ -47,6 +48,12 @@ networks:
         cloud_properties: {}
       - range: 10.244.8.20/30
         reserved: [10.244.8.21]
+        cloud_properties: {}
+      - range: 10.244.8.24/30
+        reserved: [10.244.8.25]
+        cloud_properties: {}
+      - range: 10.244.8.28/30
+        reserved: [10.244.8.29]
         cloud_properties: {}
 
 resource_pools:
@@ -58,28 +65,31 @@ resource_pools:
     cloud_properties: {}
 
 jobs:
-  - name: docker
+  - name: swarm-broker
     templates:
-      - name: docker
+      - name: swarm_manager
+      - name: cf-containers-broker
     instances: 1
     resource_pool: default
-    persistent_disk: 65536
+    persistent_disk: 32768 # used for swarm_manager meta data and to please cf-containers-broker; increase as you see need
     networks:
       - name: default
         default: [dns, gateway]
         static_ips:
           - 10.244.8.2
 
-  - name: swarm
+  - name: docker
     templates:
-      - name: swarm_manager
-    instances: 1
+      - name: docker
+    instances: 2
     resource_pool: default
+    persistent_disk: 65536 # actual data volumne; increase as you see need
     networks:
       - name: default
         default: [dns, gateway]
         static_ips:
           - 10.244.8.6
+          - 10.244.8.10
 
 properties:
   docker:
@@ -87,4 +97,72 @@ properties:
 
   swarm_manager:
     docker_nodes:
-      - 10.244.8.2
+      - 10.244.8.6
+      - 10.244.8.10
+
+  nats:
+    user: nats
+    password: nats
+    port: 4222
+    machines:
+      - 10.244.0.6
+
+  cfcontainersbroker:
+    name: cf-containers-broker
+    external_host: "cf-containers-broker.10.244.0.34.xip.io"
+    auth_username: 'containers'
+    auth_password: 'containers'
+    cookie_secret: 'e7247dae-a252-4393-afa3-2219c1c02efd'
+    cc_api_uri: "https://api.10.244.0.34.xip.io"
+    component_name: 'cf-containers-broker'
+    monit_dependency: 'swarm_manager'
+    docker_url: "unix:///var/vcap/sys/run/swarm_manager/swarm_manager.sock"
+    max_containers: 20
+
+    services:
+      - id: '2fd814ac-d1f7-4d4a-a4f7-d386cd8fd8e3'
+        name: 'postgresql93'
+        description: 'PostgreSQL 9.3 service for application development and testing'
+        bindable: true
+        tags:
+          - 'postgresql93'
+          - 'postgresql'
+          - 'relational'
+        metadata:
+          displayName: 'PostgreSQL 9.3'
+          imageUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAAA/CAYAAABQHc7KAAAQsklEQVR42t1bCViV5bYm55QcykZLu7fzVLeySbtXj2iePGoeJ46mHkXUzq1EKeWAmgpqqJgTZuCAqImKgYiKmiMOCAKCIwICAgIyyTzPwzrrXfw/bRE2e2+t59D3POvZsPf/f//3vftb07vWNjLSbbRh6cNi06ZNG0djY2MXyJNPPunM/2/g91ezzGP5G0s3LfO8xvIl37u1e/fu7i+++OLBHj16HOFX765du+7CfPz59zzn2mefffbnnj17nuX/I1hSWfJYSlmqFClgSWeJ4/n8nn/+eY927dp9x/9/yPKE0WMcr7P4sCSwlLDUslADwXuVLLksMSweLP9QgFOHGUsUS34j9zeUGvVvBoWGDh1KFhYW5OjoSO7u7rRjxw5atGgRmZub0/vvv9/wPoCyjeWpR9l0K5YB+MZZ7r300kv0wQcf0JgxY+Shc+fOJTs7O3n94osvaNq0aTRhwgQaNmwYffjhh9SrVy/q1KkTFnOVxZ7Fhb+ditdee42GDBlCM2bMoOXLl8tGfHx8aP/+/bRx40aysrKiSZMmyVy2trbk6+tLRUVFVFtbS5VV1VRUWk65haWUX1RKpeUVVFVdTVVVVRQaGkpr1qyhyZMn03vvvYdnA4xzLMPNzMxeNgSA71nKn3jiidoFCxbIIsrKyuRhNTU1pDmwOEg1L6ayslKuKy4uppSUFLK0tKSOHTvidNSePn2aSkpKqKKiQq7HKKuopMT7uZRVUEw1yjyYX30G/j8WdJtM7dxo4NwtNHDOFjJRBH8P4vcsNhykmHuZ9feWlpZSWloamZiYqKeyuFWrVnP02fxMHKW3336bzpw5IxurqKymy5FJtMbjAn2x7gCN5QUNX7CDTJe40T+W76N/rvWiha4naOuRYPIPu0vZ+cX1ABUUFFBiYqL8XVpWSQf8wmTRf7VxpT4zf6yX/pbONH7Zbprv8gsdDYyknMISuQfPPn0lhqZ97/nA9Q3lb9+yWmw/QYnpuXJfZmYmTZkyhXjzOA3JLG80t3EYDmsYGBxTLLyquoZ+CYqkITbbtD68MZlkv5cycotkMTi+G7396SML/eYwc/iZfK/GMghVVFhSRgt5g/8327nZ+6w2HaHYlEz+8mro1KlThC+T91XduXNnsyZ3z1a0Nx/5In6lrKwsKiguE0R1eWBjMuuHQ1TOCwcIXzkeNGgOSF8LJ/pqgzdFJWUImDdiU2jCd3ubve8T620UFJEoqnH16lXivQGECvYwQ5rCYAJQWr9+vdy01tPP4EWbfLNZ9LKcdXyOs4/B82jKqMU/UXJmnoBQzMbwr/Ncm73n47lb6cadFNkPbFnr1q0BwtGmjv/xd999tzYvL49RTqUBvAlDFtrPchP5XIpgK11Ji9guPI7NqzKRv/njl29TNRu7I/wM2I3m7hls5UK/BN8WWwYvxvvMZvnvhgBM46NBkZGRgjB0yNBFwiBWsM7jyMJyP04A6lTiRza2QeIC76bnPGRMG5PP1+yXU3Dp0iU1Zlmoufm2OBYvvPAC5ebmimvqZ6DeQ3YeDxUQjwRGUN/HvHlNCWavhAEwmrv2U/YQcLMw7ErAtFkTgN4s8b179xZ/HxJ175EWlpKVT3Gp2WKE+vyGAMBDZOYXUVp2AQ2dt13rtYPYFtTU1MUZiCx5v8c0ATBnyRk0aJAEMZ7nbxq8qPFL98hD1nv5/aabV2Xyin3i6gJuJWi9Dp4MAGAgquX9XtMEYD6ivhEjRkgk57jf8MX/4B0gxs/MweN3AQCCSBHu1nxV0880mbO5HgBOugCAvyYAdggZR40aJaGu/W5fA62/M4Wy+sTz8ceR+70AgMHGCAxv+hTAUMIGlJeXqzZgryYASFaq4SIAwJKfThm0kMH/cqGkjFwK5uDj99q86uuRWkBmbmg84Bq9eJcAgJBcAWCVJgArEfubmpoKALY7Thq0kOHzt3O4Ws5xfAT97ywn+gsDMtp2l/juOc5HyPLHw/R3zh10cVtNCRKgMbwZ6y3H6GJYPMWlZMmJg+fCOHv1TpO2ArYpICBAdYOWmgAg/q/49NNPxQb8wDG7IYszZ70XX3vrLgVFJlAC++jisnKNzK4uJ0jJzJcQW9/5h3LkF3I7iVPiumwyJjmTzl6LpXPXYylPSZyuNOHBoCa4x97enhRS5c+aAIyFFxgwYIB4Ae+LtwwCYK6ii+pANnf4UjhZbz5K45bu5qzRnVyOBks+j89GLtqp1/wzOR9AZogQ24ZPALJD81WectoO+YfLM0+GRjd673duZwSAiRMnksIsvdSQ8UkCkYA8PtBAHV6264wsAhGa14WbErsjaoML2n3qCkUm3CengwG080SoWOTlehpbn4AIPupVNH7JbjoVGiOESG5BCZna7RZ1wPA4d6PRe50OXRIAFPboXkPKDLTVxVdeeYWQB2TmFRkEwCr3c7KIn3iDfRv44C0+QZTOAcvNuFT+Nk7Ldek5hXrNj3Ud49RcdHrlPvZWZ2iq4m6hVhhrPM43em/0vQy6fPkytW3bFgB4NcoAPfXUU5SdnS1ImRiQCKkqsLEJG/LnrzcLGLDaqk34xNpF5/lh7HyvPWzkoAIqw/SVo/dDn09nVcHnoOsUD2DZGABDwZxER0fLRFM5zNQXgP9fe0Du3ewTqD2ZYcnIK5RrzVbq/pzzN+IoNiX7offhbTBgbIc2SJE/YnBgKJHjKKlwzeLFi99pig8oXr16tUzmsPes3gCA5sJwZn1rVp8v1RktGDNd59/g5S/fJIzpA1TYwp0yF1zwQ+mzvTt7ogoKDg5WCZEwbZRYCI4JhmcTxkSbfOt6XO5dv/9is9duO3pZrrXbqXvQNf37/eIF3E5eecg9qicA6qD5GUgdBEBgnZXj/4M2AH5kNRBC5GZcmv5GcN955fSca/ZaB8VgrnQ/p/P8YIZz2OpHJKQ/YKMGW22td70IxjRtQ7RCo4ENUmoGI7UBMA6EqJubG1VwRKhvxAb3hrF4e/ORJHJ4jCV6nAAwVLEc+SGYcvTyf2Cj6gBjrb4/e+MhUZmoqCiCgVeKNW21AWDCUjZz5ky5sam4uilRgxFrHfQaGZwwTxwk6fMM+PM6er2CT8GvbBNOBgZco/re7tNXRS1QaFHqAz20cuJTp079E1vKgnfeeUcA2KID06IpCEkxLBn55q6N4KAI459rvPR6Rn/LTULY1NF2v4IXFJEg7+09c72eEY5LzaJr166RsbExAAhvtl44b968Tmwps2As0tPT6U5yll6LuxKdLIuY2YgvfpCd2VKfH8CC62trpnLeX8JR4MmQ6PqAy+9mXST487k6AJwPBcozRo4cKcava9eue3StCqEaS15eXhKujl+2R+eFqYuwctZOqIK4wEjNyjeMFGU5ywERSBBwfXgvKrHuRG06HEh/4eAK2WF8fLzq+kgp1Oo0/sRSNHr0aJnwWkyyzgTpv1ifoTquxy5rvc7R66LQ2sv3+BqcFg+Ys1lqihkcHk/hYAq+HmPprtMCDtYxa9YsNfVdMXjw4Db61AbPdOjQQVLjYk49danCqHqH+P56bAp9ZOHU6DV4H4lLTkExZ4M/PRIRcuBCmGz0VGhd9ApQP+O14mRBhV999VUAcIeli76V4QU4OiEhIaIGC3UsbmBzsO4A7cv1Bxqnp9lP49s6GBD+yEyQzZajsj48DyMkKkkiS2SjmzZtUkPflYY0SyA9rpk/f75M7OWnO0uMctW9jDwqKCkj2x2nHjgJ+BvsLT4ztOrUMM739rslrDAKMVA9gOvt7a1mfbcnTJjwZIOst5WuINx+5plnpE6QnKmfsVqw7bgEK1iMw75z9SBMVYxfaPS9x8oJItkBCLlFJVL4QCOHYvjWK10ptixuLBdYTrBMYemgdfedO3deiknYNVIFW9SvmnFtD2RnbIVv3U0XNwQdRRq7/ZcQYZowfK/eEa7Q5DGcAsiKPWfrI8G7d+8SKlxYO9QYRZAuXbrQc889JzYBr0pIbKMVAHNz807o5enYsSP5+/tLDW7Y/O06Legw6zcMEupwsMTIxDS7SuCistkIYs5HNYROhwIoS6MZA5ReTEyMlMPDwsLkb7jDpKQkMYx4RaAHT8fySnNq4AkkHRwcpFECR7u5BVmzYaqqqhFe4c0336xvXnr55ZfpwoULskjYiKSMujK3+9nrBm9+xpr9AnRecSm5+14jL/YKGbmF9QUQtcUGgOcVltaTJnDx2oiRhmQpqTEB/K62BY2128V6WCqtKUpHRr2g6QJ8I2zDtFWeNGzBdkri+cDsguo2BAAwT9jUQYXE7atUgGas9qQNB/xp8Y6TUg9AhXqt5wW5Fv1D3bp1w5rKmnWPbEFb88sG1qNaT09PJddvvGwGDgAdXIWFhdIFhi6t4cOH06pVq+jw4cOUn59P/uz/x7DuqyXu89fj5J6J9nsNAuDnszdkTQ0DL7ThjOAIERWuo0GRFJ+WQ8UlJYTGjzfeeAObL1SaQXQanVkie/bsScnJyVKJHfHtzgZp6iYJgBA4ff7552RmZibkqjpwTFEv1GRyTJfultOCdjdQ5oYAcDggop4IQUU6ODKRwuLTJER+QAXYLqxYsUKzj3CpXkFBjx49rGFRoQo43tH3MoV9RUxv7+ZLtxMzKCEhQQweBECA88M3vJlj84Wux2moBreAbDE1q0AWjhqB6RLDADhxOUo2CWMHm5Oamiqlr+vXr4u9cXV1JaT2ffr0gUdAZ2kg78Xum2++aa9vYNRaqabWfPbZZ0Iwag7oVb9+/QThr7/+uq5fkHUd/AB8PxIqlKbWefpRWlYdfZ2Tk0N+fn6Uxyfg7wYCgAYoDE1j24jA2iexODxquyy6LcPBHKO4sG7dOgoPD5eQc+DAgWrYSe3atSPVXqhHsC4e+BUwfFsowqDV9VEACItP1yx3a7bsQsdjlWbPvizPPq7e4efbtGlzUen1rdZ4YAEfsSCFckpr3769NCh6eHhIMTIwMFBe0a+3bNkycYm4FzwdABhnIAB32bihnU9Zy/8ojU9djH7L8dZbbxnzy3+xfMCCzuxRyoONlTgbtJOjQkERwFBF6diEpOAVuQaKmuOWuBkEAMBD47TSNf4fN3qymLKsgytVdNCKpf/06dPfVsPs/MJiBmCXQaRIFdsZNFfzXJlGLWnY2toiBCUbGxsGoIjG2ekfDk+ydxe7olHsbDmDN94dAFhbWxsMAGoQ6DxX0t47LQqA2bNnG6sus4BVYLwBKgCOAj4fzZ0NO77+44cSYktMgV7iKSvc9QYgnCO+oKAgMawcdp82aoEjo3///uLHLfQswHxstVVSYLhZRKi9evXa0xIBuPT666/XldL0bMrCjzTQyu/k5CRu9emnn97YEgH4EvqL7BG/DtEHAPT7IMFiW6LGFRNbIgAInspu3LhBuQXFejVVq03SSLuVSLRbSwTgGfzeT80bbHWsEqOJE/kF+hmRojfs+m5JA8mJy9ixYyV7BM8w1la7O5y8fJ80SiG/R67B9weztDNqwaNnhw4dil1c6np80EbXMDNENRi/IsOvxlDwALOE+EHJK8yN/gDjEPQYmSKIFBCaN+NThecLjEgQa490Gk3O9+/flzRa+dlszIgRI9q3+N2zK3yTX26Cfkd/EvgF0OhxcXHyCl/PyROhi5X9fS37/ZN8/WglK/3DDOTw5/GbhSZYHbyfqFR3uhj9QQdqeJ8gPmCZo6TOFizTWT5m6f5bPfjf9dGSlnLSEoEAAAAASUVORK5CYII='
+          longDescription: 'A PostgreSQL 9.3 service for development and testing running inside a Docker container'
+          providerDisplayName: 'Pivotal Software'
+          documentationUrl: 'http://docs.run.pivotal.io'
+          supportUrl: 'http://support.run.pivotal.io/home'
+        dashboard_client:
+          id: 'p-postgresql93-client'
+          secret: 'p-postgresql93-secret'
+          redirect_uri: "http://cf-containers-broker.10.244.0.34.xip.io/manage/auth/cloudfoundry/callback"
+        plans:
+          - id: '1a0efffc-eb45-4bf8-8ee3-a3c1a9a53151'
+            name: 'free'
+            container:
+              backend: 'docker'
+              image: 'frodenas/postgresql'
+              tag: 'latest'
+              persistent_volumes:
+                - '/data'
+            credentials:
+              username:
+                key: 'POSTGRES_USERNAME'
+              password:
+                key: 'POSTGRES_PASSWORD'
+              dbname:
+                key: 'POSTGRES_DBNAME'
+              uri:
+                prefix: 'postgres'
+            description: 'Free Trial'
+            metadata:
+              costs:
+                - amount:
+                    usd: 0.0
+                  unit: 'MONTHLY'
+              bullets:
+                - 'Dedicated PostgreSQL 9.3 server'
+                - 'PostgreSQL 9.3 running inside a Docker container'

--- a/jobs/cf-containers-broker/monit
+++ b/jobs/cf-containers-broker/monit
@@ -1,8 +1,8 @@
 check process cf-containers-broker with pidfile /var/vcap/sys/run/cf-containers-broker/cf-containers-broker.pid
   group vcap
-  start program "/var/vcap/packages/bosh-helpers/monit_debugger cf-containers-broker_ctl '/var/vcap/jobs/cf-containers-broker/bin/cf-containers-broker_ctl start'"
+  start program "/var/vcap/packages/bosh-helpers/monit_debugger cf-containers-broker_ctl '/var/vcap/jobs/cf-containers-broker/bin/cf-containers-broker_ctl start'" with timeout 300 seconds
   stop program "/var/vcap/packages/bosh-helpers/monit_debugger cf-containers-broker_ctl '/var/vcap/jobs/cf-containers-broker/bin/cf-containers-broker_ctl stop'"
-  depends on docker
+  depends on <%= p('cfcontainersbroker.monit_dependency') %>
 
 <% if_p('remote_syslog.address', 'remote_syslog.port', 'remote_syslog.protocol') do |address, port, protocol| %>
 check process cf-containers-broker_remote_syslog with pidfile /var/vcap/sys/run/cf-containers-broker/remote_syslog.pid

--- a/jobs/cf-containers-broker/spec
+++ b/jobs/cf-containers-broker/spec
@@ -18,6 +18,9 @@ templates:
   config/unicorn.conf.rb.erb: config/unicorn.conf.rb
 
 properties:
+  cfcontainersbroker.external_ip:
+    description: 'External IP of docker VM'
+    default: nil
   cfcontainersbroker.user:
     description: 'User which will own the CF-Containers-Broker services'
     default: 'root'
@@ -52,6 +55,12 @@ properties:
   cfcontainersbroker.skip_ssl_validation:
     description: 'Determines whether dashboard verifies SSL certificates when communicating with Cloud Controller and UAA'
     default: true
+  cfcontainersbroker.monit_dependency:
+    description: 'Monit dependency for cf-containers-broker monit script'
+    default: 'docker'
+  cfcontainersbroker.docker_url:
+    description: 'Sets the socket URL how to reach docker'
+    default: 'unix:///var/vcap/sys/run/docker/docker.sock'
   cfcontainersbroker.max_containers:
     description: 'Max number of containers'
     default: '0'

--- a/jobs/cf-containers-broker/templates/bin/cf-containers-broker_ctl
+++ b/jobs/cf-containers-broker/templates/bin/cf-containers-broker_ctl
@@ -17,7 +17,6 @@ case $1 in
 
   start)
     pid_guard ${CF_CONTAINERS_BROKER_PID_FILE} ${JOB_NAME}
-    echo $$ > ${CF_CONTAINERS_BROKER_PID_FILE}
 
     # Create CF-Containers-Broker user & group
     create_group ${CF_CONTAINERS_BROKER_GROUP}
@@ -37,9 +36,6 @@ case $1 in
           >>${CF_CONTAINERS_BROKER_LOG_DIR}/fetch_containers_images.stdout.log \
           2>>${CF_CONTAINERS_BROKER_LOG_DIR}/fetch_containers_images.stderr.log
     fi
-
-    # We remove the PID file (own process) to prevent a collision with Unicorn
-    rm -fr ${CF_CONTAINERS_BROKER_PID_FILE}
 
     # Start CF-Containers-Broker
     exec chpst -u ${CF_CONTAINERS_BROKER_USER}:${CF_CONTAINERS_BROKER_GROUP} \

--- a/jobs/cf-containers-broker/templates/bin/job_properties.sh.erb
+++ b/jobs/cf-containers-broker/templates/bin/job_properties.sh.erb
@@ -36,8 +36,8 @@ export RAILS_ENV=production
 # CF-Containers-Broker settings file
 export SETTINGS_PATH=$CF_CONTAINERS_BROKER_CONF_DIR/settings.yml
 
-# Docker UNIX socket
-export DOCKER_URL="unix:///var/vcap/sys/run/docker/docker.sock"
+# Docker URL
+export DOCKER_URL="<%= p('cfcontainersbroker.docker_url') %>"
 
 #
 # Remote Syslog properties

--- a/jobs/cf-containers-broker/templates/config/settings.yml.erb
+++ b/jobs/cf-containers-broker/templates/config/settings.yml.erb
@@ -14,7 +14,7 @@ production:
     end
 
     networks = openstruct_to_hash(spec.networks)
-    external_ip = networks.values.find { |net| net.has_key?(:default) }[:ip]
+    external_ip = p('cfcontainersbroker.external_ip', networks.values.find { |net| net.has_key?(:default) }[:ip])
    %>
   external_ip: <%= external_ip %>
   external_host: <%= p('cfcontainersbroker.external_host') %>

--- a/jobs/swarm_manager/templates/bin/swarm_manager_ctl
+++ b/jobs/swarm_manager/templates/bin/swarm_manager_ctl
@@ -10,7 +10,6 @@ case $1 in
 
   start)
     pid_guard ${SWARM_MANAGER_PID_FILE} ${JOB_NAME}
-    echo $$ > ${SWARM_MANAGER_PID_FILE}
 
     # Create Swarm Manager user & group
     create_group ${SWARM_MANAGER_GROUP}
@@ -24,11 +23,13 @@ case $1 in
     (crontab -l | sed /swarm_manager.*logrotate/d; cat ${SWARM_MANAGER_CONF_DIR}/swarm_manager_logrotate.cron) | sed /^$/d | crontab
 
     # Start Swarm Manager daemon
+    echo $$ > ${SWARM_MANAGER_PID_FILE}
     exec chpst -u ${SWARM_MANAGER_USER}:${SWARM_MANAGER_GROUP} swarm \
         ${SWARM_MANAGER_DEBUG:-} \
         ${SWARM_MANAGER_LOG_LEVEL:-} \
         manage \
         --rootdir=${SWARM_MANAGER_ROOT_DIR} \
+        --host unix://${SWARM_MANAGER_PID_DIR}/swarm_manager.sock \
         ${SWARM_MANAGER_HOST:-} \
         ${SWARM_MANAGER_STRATEGY:-} \
         ${SWARM_MANAGER_HEARTBEAT:-} \


### PR DESCRIPTION
#### Purpose
Extend Swarm job/deployment to include a broker and become operational with CF.

#### Motivation
The current Swarm setup is basically only a Swarm without a broker and can't be used/integrated as such into CF, i.e. there are no means out-of-the-box to scale this bosh release horizontally by adding more Docker nodes (orchestrated by Swarm).

#### Proposal
Add broker support so that the swarm job/deployments can be used with CF.

#### Changes
* Added broker and its configuration to the Swarm bosh-lite example (only)
* Extensions and new properties to override defaults that need different values with Swarm
* Split Docker nodes from Swarm/broker node; put Swarm and broker together on one node
* Have 2 Docker nodes for demonstration purposes
* Support usage of elastic IPs
* Changes in monit returning only when started (broker, i.e. Unicorn and Swarm)

#### Note of caution
Changes were done, tested, and put to production only with our own cloud infrastructure which is neither of the supported ones. However, the bosh-lite setup was used to develop the changes and tested. If interested, details can be discussed offline about how e.g. the AWS deployment example could be tweaked. In other words, only the bosh-lite Swarm deployment example includes a broker.

#### CC
@frodenas @holgerkoser
