### PR TITLE
Swarm health checker

### DIFF
--- a/jobs/swarm_manager/monit
+++ b/jobs/swarm_manager/monit
@@ -2,7 +2,13 @@ check process swarm_manager with pidfile /var/vcap/sys/run/swarm_manager/swarm_m
   group vcap
   start program "/var/vcap/packages/bosh-helpers/monit_debugger swarm_manager_ctl '/var/vcap/jobs/swarm_manager/bin/swarm_manager_ctl start'"
   stop program "/var/vcap/packages/bosh-helpers/monit_debugger swarm_manager_ctl '/var/vcap/jobs/swarm_manager/bin/swarm_manager_ctl stop'"
+  if (failed url http://127.0.0.1:9999/ and content == "fresh") then restart
 
+check process swarm_manager_health_checker with pidfile /var/vcap/sys/run/swarm_manager/swarm_manager_health_checker.pid
+  group vcap
+  start program "/var/vcap/packages/bosh-helpers/monit_debugger swarm_manager_health_checker_ctl '/var/vcap/jobs/swarm_manager/bin/swarm_manager_health_checker_ctl start'"
+  stop program "/var/vcap/packages/bosh-helpers/monit_debugger swarm_manager_health_checker_ctl '/var/vcap/jobs/swarm_manager/bin/swarm_manager_health_checker_ctl stop'"
+  
 <% if_p('remote_syslog.address', 'remote_syslog.port', 'remote_syslog.protocol') do |address, port, protocol| %>
 check process swarm_manager_remote_syslog with pidfile /var/vcap/sys/run/swarm_manager/remote_syslog.pid
   group vcap

--- a/jobs/swarm_manager/spec
+++ b/jobs/swarm_manager/spec
@@ -10,6 +10,8 @@ templates:
   bin/job_properties.sh.erb: bin/job_properties.sh
   bin/remote_syslog_ctl: bin/remote_syslog_ctl
   bin/swarm_manager_ctl: bin/swarm_manager_ctl
+  bin/swarm_manager_health_checker_ctl: bin/swarm_manager_health_checker_ctl
+  bin/swarm_manager_health_checker: bin/swarm_manager_health_checker
   config/docker.cacert.erb: config/docker.cacert
   config/docker.cert.erb: config/docker.cert
   config/docker.key.erb: config/docker.key

--- a/jobs/swarm_manager/templates/bin/swarm_manager_health_checker
+++ b/jobs/swarm_manager/templates/bin/swarm_manager_health_checker
@@ -23,8 +23,18 @@ def total_containers
   json_from_url('http://localhost:2375/containers/json').length
 end
 
+def expected_nodes
+  <%= p('swarm_manager.docker_nodes').length %>.to_i
+end
+
+def number_of_nodes
+  json_from_url('http://localhost:2375/info')['DriverStatus']
+    .select { |s| s[0] =~ /Nodes/  }.flatten.last.to_i
+end
+
 def stale?
-  info_total_containers != total_containers
+  info_total_containers != total_containers ||
+  expected_nodes != number_of_nodes
 end
 
 server.mount_proc '/' do |req, res|

--- a/jobs/swarm_manager/templates/bin/swarm_manager_health_checker
+++ b/jobs/swarm_manager/templates/bin/swarm_manager_health_checker
@@ -1,0 +1,34 @@
+#!/var/vcap/packages/ruby/bin/ruby
+require 'json'
+require 'open-uri'
+require 'webrick'
+
+server = WEBrick::HTTPServer.new(Port: 9999, DoNotReverseLookup: true)
+trap('INT') { server.shutdown }
+
+def json_from_url(url)
+  begin
+    JSON.parse(open(url).read)
+  rescue
+    # return fresh when connection errors
+    return { 'Containers' => 1 }
+  end
+end
+
+def info_total_containers
+  json_from_url('http://localhost:2375/info')['Containers']
+end
+
+def total_containers
+  json_from_url('http://localhost:2375/containers/json').length
+end
+
+def stale?
+  info_total_containers != total_containers
+end
+
+server.mount_proc '/' do |req, res|
+  res.body = stale? ? "stale" : "fresh"
+end
+
+server.start

--- a/jobs/swarm_manager/templates/bin/swarm_manager_health_checker_ctl
+++ b/jobs/swarm_manager/templates/bin/swarm_manager_health_checker_ctl
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Setup common env vars and folders
+source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'swarm_manager' 'swarm_manager_health_checker'
+export PID_FILE="$RUN_DIR/swarm_manager_health_checker.pid"
+
+case $1 in
+
+    start)
+        pid_guard ${PID_FILE} "swarm_manager_health_checker"
+        echo $$ > ${PID_FILE}
+
+        exec chpst -u vcap:vcap ${JOB_DIR}/bin/swarm_manager_health_checker \
+             >>${LOG_DIR}/${OUTPUT_LABEL}.stdout.log \
+             2>>${LOG_DIR}/${OUTPUT_LABEL}.stderr.log
+        ;;
+
+    stop)
+        kill_and_wait ${PID_FILE}
+        ;;
+
+    *)
+        echo "Usage: $0 {start|stop}"
+        exit 1
+        ;;
+
+esac
+exit 0


### PR DESCRIPTION
Fixes: https://github.com/cf-platform-eng/docker-boshrelease/issues/35

This PR adds a health check for the edge case described in the above issue.
Currently there are 2 cases which are checked:
1. mismatch between number of containers reported in info and in the containers list
2. mismatch between number of nodes reported in info and the bosh nodes array

If one of the above criteria is met the swarm manager is restarted.

To observe this, one can create a service instance and recreate the docker node on which is it running, during this process running `watch docker -H=tcp://10.244.8.2:2375 ps`.
The service wil disappear from the docker ps results, and later reappear.
