### PR TITLE
Add configurable login parameters

### DIFF
--- a/jobs/containers/spec
+++ b/jobs/containers/spec
@@ -61,3 +61,6 @@ properties:
       containers.volume_driver: Optional string containing the volume driver for the container
       containers.workdir: Optional string containing the working directory inside the container
       containers.store_dir: Optional string containing directory to store the containers data files
+      containers.login.server: Optional string containing the server address to login to before pulling the container image
+      containers.login.username: Optional string containing the username to login with before pulling the container image
+      containers.login.password: Optional string containing the paswword to login with before pulling the container image

--- a/jobs/containers/templates/bin/ctl
+++ b/jobs/containers/templates/bin/ctl
@@ -35,6 +35,17 @@ case $1 in
         fi
     fi
 
+    # Log in to private registry if necessary for pulling
+    if [ ! -z "$(eval echo "\$${container_name}_login")" ]
+    then
+        image="$(eval echo "\$${container_name}_image")"
+        login_opts="$(eval echo "\$${container_name}_login")"
+        echo "$(date) Logging in to custom registry"
+        ${DOCKER_COMMAND} login ${login_opts}
+        echo "$(date) Pulling image ${image}"
+        ${DOCKER_COMMAND} pull ${image}
+    fi
+
     # Start Docker container
     docker_options="run --detach \
       --name ${container_name} \

--- a/jobs/containers/templates/bin/job_properties.sh.erb
+++ b/jobs/containers/templates/bin/job_properties.sh.erb
@@ -250,4 +250,9 @@ cat > "${CONTAINERS_CONF_DIR}"/<%= container['name'] %>/Dockerfile <<DOCKERFILE
 <%= container['dockerfile'] %>
 DOCKERFILE
 <% end %>
+
+<% if container['login'] %>
+export <%= container['name'] %>_login="--username <%= container['login']['username']  %> --password <%= container['login']['password'] %> <%= container['login']['server'] %>"
+<% end %>
+
 <% end %>


### PR DESCRIPTION
Hi, 

similar to the issue #77 and PR #104 I think that not having the option to use images from a private (i.e. login-protected) registry is quite a limitation. I tried a different, simpler approach than #104, that consists in maintaining the login information at the container job and adding a docker login and docker pull to the ctl before starting the container.

What do the maintainers think about this approach? 
I gathered that there are more people trying to do this.

**Change:**

Add configurable login parameters to pull images from
custom (private) docker registries where authentication is
needed.

* Add properties login.name, login.password, login.server to
  container job and create environment variable for login
  parameters from these properties
* Add docker login and docker pull commands to job ctl that
  is executed if the login properties are set