### PR TITLE
Add logrotate property for containers

### DIFF
--- a/jobs/containers/spec
+++ b/jobs/containers/spec
@@ -38,6 +38,7 @@ properties:
       containers.links: Optional array of links to another containers (name:alias)
       containers.log_driver: Optional string containing the log driver for the container
       containers.log_options: Optional array of log driver options
+      containers.log_rotate: Optional content of a logrotate file for this container
       containers.lxc_options: Optional array of custom lxc options
       containers.mac_address: Optional string containing the container MAC address
       containers.memory: Optional string containing the memory limit to assign to the container (format: <number><optional unit>, where unit = b, k, m or g)

--- a/jobs/containers/templates/bin/job_properties.sh.erb
+++ b/jobs/containers/templates/bin/job_properties.sh.erb
@@ -144,6 +144,11 @@ export <%= container['name'] %>_log_driver="--log-driver=<%= container['log_driv
 export <%= container['name'] %>_log_options="<%= Array(container['log_options']).join(',').split(',').map { |log_option| "--log-opt=#{log_option}" }.join(' ') %>"
 <% end %>
 
+<% if container['log_rotate'] %>
+# Write log rotate file for the container
+echo -e "<%= container['log_rotate'] %>" > /etc/logrotate.d/<%= container['name'] %>
+<% end %>
+
 <% unless container['lxc_options'].nil? || container['lxc_options'].empty? %>
 # Custom lxc options
 export <%= container['name'] %>_lxc_options="<%= Array(container['lxc_options']).join(',').split(',').map { |lxc_option| "--lxc-conf=#{lxc_option}" }.join(' ') %>"


### PR DESCRIPTION
Standard docker container logs are only available for as long as
the container is running, since a monit stop also removes the
container (including logs) using docker rm.

To properly persist logs even after a container is stopped or
restarted it seems that you have to write your own application logs
and bind-mount the log directory to a persistent disk.

However, logs are not rotated this way.

To avoid the necessity of doing manual configurations to the bosh
release or on a VM, make custom logrotation settings possible via
a container property.