### PR TITLE
Switch to GCS blobstore

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -1,7 +1,7 @@
 ---
 final_name: docker
 blobstore:
-  provider: s3
+  provider: gcs
   options:
     bucket_name: docker-boshrelease-blobs
     region: us-east1


### PR DESCRIPTION
Wrong blobstore caused `"https:/docker-boshrelease-blobs/...": remote error: tls: handshake failure`.